### PR TITLE
Added information on values 36-43 for `$arresult?` for freestyle libre

### DIFF
--- a/src/abbott/freestyle-libre.md
+++ b/src/abbott/freestyle-libre.md
@@ -186,16 +186,18 @@ change event.
   33. `custom-comment-4 = DQUOTE *VCHAR DQUOTE` ‡
   34. `custom-comment-5 = DQUOTE *VCHAR DQUOTE` ‡
   35. `custom-comment-6 = DQUOTE *VCHAR DQUOTE` ‡
-  36. `unknown` †
-  37. `unknown` †
-  38. `unknown` †
-  39. `unknown` †
-  40. `unknown` †
-  41. `unknown` †
-  42. `unknown` †
-  43. `unknown` †
+  36. `unknown = "7"` †
+  37. `month = 1*2DIGIT` * †
+  38. `day = 1*2DIGIT` * †
+  39. `year = 1*2DIGIT` * †
+  40. `hour = 1*2DIGIT` * †
+  41. `minute = 1*2DIGIT` * †
+  42. `second = 1*2DIGIT` * †
+  43. `unknown = "1"` * †
   44. Value of rapid acting insulin in 0.5 IE. If you want proper IE, divide by
       2.
+
+\* These values are identical to values 3-9, regardless of what time the notes were added to the record. Which seems to make them entirely redundant.
 
 † The number of columns in a record can be different. If a rapid acting insulin
 value has been set, then it is > 44, otherwise the record has only entries up to


### PR DESCRIPTION
I've noticed that in all my entries where rapid acting insulin was added, the extra values (36-43) were "7", followed by the date and time, followed by a 1.

The date and time were identical to 3-9, even when I waited a minute (the device clock was different) before adding the note containing the rapid acting insulin.